### PR TITLE
Add producer and consumer span kinds to zipkin V2 receiver

### DIFF
--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -384,6 +384,8 @@ func zipkinSpanToTraceSpan(zs *zipkinmodel.SpanModel) (*tracepb.Span, *commonpb.
 		}
 	}
 
+	kind, kindAttr := zipkinSpanKindToProtoSpanKind(zs.Kind)
+
 	pbs := &tracepb.Span{
 		TraceId:      traceID,
 		SpanId:       spanID,
@@ -391,10 +393,19 @@ func zipkinSpanToTraceSpan(zs *zipkinmodel.SpanModel) (*tracepb.Span, *commonpb.
 		Name:         &tracepb.TruncatableString{Value: zs.Name},
 		StartTime:    internal.TimeToTimestamp(zs.Timestamp),
 		EndTime:      internal.TimeToTimestamp(zs.Timestamp.Add(zs.Duration)),
-		Kind:         zipkinSpanKindToProtoSpanKind(zs.Kind),
+		Kind:         kind,
 		Status:       extractProtoStatus(zs),
 		Attributes:   zipkinTagsToTraceAttributes(zs.Tags),
 		TimeEvents:   zipkinAnnotationsToProtoTimeEvents(zs.Annotations),
+	}
+
+	if kindAttr != nil {
+		if pbs.Attributes == nil {
+			pbs.Attributes = &tracepb.Span_Attributes{AttributeMap: map[string]*tracepb.AttributeValue{}}
+		}
+		for k, v := range kindAttr.GetAttributeMap() {
+			pbs.GetAttributes().GetAttributeMap()[k] = v
+		}
 	}
 
 	return pbs, node, nil
@@ -511,14 +522,22 @@ var canonicalCodesMap = map[string]int32{
 	"UNAUTHENTICATED":     16,
 }
 
-func zipkinSpanKindToProtoSpanKind(skind zipkinmodel.Kind) tracepb.Span_SpanKind {
+func zipkinSpanKindToProtoSpanKind(skind zipkinmodel.Kind) (tracepb.Span_SpanKind, *tracepb.Span_Attributes) {
 	switch strings.ToUpper(string(skind)) {
 	case "CLIENT":
-		return tracepb.Span_CLIENT
+		return tracepb.Span_CLIENT, nil
 	case "SERVER":
-		return tracepb.Span_SERVER
+		return tracepb.Span_SERVER, nil
 	default:
-		return tracepb.Span_SPAN_KIND_UNSPECIFIED
+		return tracepb.Span_SPAN_KIND_UNSPECIFIED, &tracepb.Span_Attributes{
+			AttributeMap: map[string]*tracepb.AttributeValue{
+				"span.kind": {
+					Value: &tracepb.AttributeValue_StringValue{
+						StringValue: &tracepb.TruncatableString{Value: strings.ToLower(string(skind))},
+					},
+				},
+			},
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

closes https://github.com/hypertrace/javaagent/issues/156


## Description

Add unrecognized span kinds as attributes in Zipkin V2 receiver. In the exporter the unrecognized span kind is not set and the span kind from the attributes is used https://github.com/hypertrace/opencensus-service/blob/main/translator/trace/jaeger/protospan_to_jaegerthrift.go#L261.


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules


